### PR TITLE
TAURI_DEV_PORT env var

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,6 @@
     "identifier": "com.paper-robin.whitenoise",
     "build": {
         "beforeDevCommand": "bun run dev",
-        "devUrl": "http://localhost:1420",
         "beforeBuildCommand": "bun run build",
         "frontendDist": "../build"
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,8 @@ import { defineConfig } from "vite";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+// @ts-expect-error process is a nodejs global
+const port = process.env.TAURI_DEV_PORT;
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
@@ -14,7 +16,7 @@ export default defineConfig(async () => ({
     clearScreen: false,
     // 2. tauri expects a fixed port, fail if that port is not available
     server: {
-        port: 1420,
+        port: port || 1420,
         strictPort: true,
         host: host || false,
         hmr: host


### PR DESCRIPTION
This allows devs to run 2 instances of the app at once by setting different TAURI_DEV_PORT on each. This is useful when trying to chat back and forth between 2 clients when testing a new feature.

If you don't specify anything then it still defaults to 1420.