### PR TITLE
Include port in window title on dev desktop builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,12 +69,14 @@ pub fn run() {
 
             setup_logging(formatted_logs_dir.clone())?;
 
-            // Open devtools on debug builds
             #[cfg(debug_assertions)]
             {
+                // Open devtools on debug builds
                 let window = app.get_webview_window("main").unwrap();
                 window.open_devtools();
                 window.close_devtools();
+                // Customize the window title based on port
+                window.set_title(&format!("White Noise (port {})", &port))?;
             }
 
             tauri::async_runtime::block_on(async move {


### PR DESCRIPTION
When running 2 instances in development, this helps dev distinguish the two instances.

<img width="204" alt="image" src="https://github.com/user-attachments/assets/7e1b2709-b662-4bf3-9592-d40f03b3318b" />
