### PR TITLE
feat(copy-npub): add copy npub button to settings page

### DIFF
--- a/src/lib/utils/__tests__/clipboard.test.ts
+++ b/src/lib/utils/__tests__/clipboard.test.ts
@@ -1,0 +1,22 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { copyToClipboard } from "../clipboard";
+import * as ClipboardManager from "@tauri-apps/plugin-clipboard-manager";
+
+vi.spyOn(ClipboardManager, "writeText").mockImplementation(async () => {
+  return;
+});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+describe("copyToClipboard", () => {
+  it("should copy text to clipboard successfully", async () => {
+    const result = await copyToClipboard("Hello", "Copy failed");
+    expect(result).toBe(true);
+  });
+
+  it("should return false when copying fails", async () => {
+    vi.spyOn(ClipboardManager, "writeText").mockRejectedValueOnce(new Error("Clipboard error"));
+
+    const result = await copyToClipboard("Hello", "Copy failed");
+    expect(result).toBe(false);
+  });
+});

--- a/src/lib/utils/clipboard.ts
+++ b/src/lib/utils/clipboard.ts
@@ -1,0 +1,12 @@
+
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+
+export async function copyToClipboard(text: string, errorMessage: string) {
+  try {
+      await writeText(text);
+      return true;
+  } catch (e) {
+      console.error(e);
+      return false;
+  }
+}


### PR DESCRIPTION
# Context
Currently is not posible to copy npub of an account in a friendly way. The hack is to inspect the html and copy the text inside. This is because the npub text is inside a button.  This button is useful to change between accounts, when you have multiple accounts, but I think that if the avatar is a button is enough to be able to change between accounts, and that way the text would be selectable too. 

# What has been done
Now the npub of an account in the settings page is not in a button and just the avatar is clickable. A new button. with a copy icon was added to copy the npub.


https://github.com/user-attachments/assets/0aeafe98-1c02-434e-bfc0-a073a22529bd

