### PR TITLE
Revert "Feat/allow multiple dev instances (#78)"

### DIFF
--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -46,62 +46,24 @@ impl Database {
 
         let db_url = format!("{}", db_path.display());
 
-        // Add detailed logging
-        tracing::info!(
-            target: "whitenoise::database",
-            "Initializing database at path: {:?}, process ID: {}",
-            db_url,
-            std::process::id()
-        );
-
         // Create database if it doesn't exist
-        tracing::info!(
-            target: "whitenoise::database",
-            "Checking if DB exists...{:?}",
-            db_url
-        );
+        tracing::info!("Checking if DB exists...{:?}", db_url);
         if Sqlite::database_exists(&db_url).await.unwrap_or(false) {
-            tracing::info!(
-                target: "whitenoise::database",
-                "DB exists at {:?}, process: {}",
-                db_url,
-                std::process::id()
-            );
+            tracing::info!("DB exists");
         } else {
-            tracing::info!(
-                target: "whitenoise::database",
-                "DB does not exist at {:?}, creating... (process: {})",
-                db_url,
-                std::process::id()
-            );
+            tracing::info!("DB does not exist, creating...");
             match Sqlite::create_database(&db_url).await {
                 Ok(_) => {
-                    tracing::info!(
-                        target: "whitenoise::database",
-                        "DB created at {:?}, process: {}",
-                        db_url,
-                        std::process::id()
-                    );
+                    tracing::info!("DB created");
                 }
                 Err(e) => {
-                    tracing::error!(
-                        target: "whitenoise::database",
-                        "Error creating DB at {:?}: {:?}, process: {}",
-                        db_url,
-                        e,
-                        std::process::id()
-                    );
+                    tracing::error!("Error creating DB: {:?}", e);
                 }
             }
         }
 
         // Create connection pool with refined settings
-        tracing::info!(
-            target: "whitenoise::database",
-            "Creating connection pool for {:?}, process: {}",
-            db_url,
-            std::process::id()
-        );
+        tracing::info!("Creating connection pool...");
         let pool = SqlitePoolOptions::new()
             .acquire_timeout(Duration::from_secs(5))
             .max_connections(10)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,9 +34,6 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_notification::init())
         .setup(|app| {
-            // Get the port from environment variable or use default
-            let port = std::env::var("TAURI_DEV_PORT").unwrap_or_else(|_| "1420".to_string());
-
             let data_dir = app
                 .handle()
                 .path()
@@ -46,22 +43,14 @@ pub fn run() {
             let logs_dir = app.handle().path().app_log_dir().unwrap();
 
             let formatted_data_dir = if cfg!(dev) {
-                PathBuf::from(format!(
-                    "{}/dev/instance_{}",
-                    data_dir.to_string_lossy(),
-                    port
-                ))
+                PathBuf::from(format!("{}/dev", data_dir.to_string_lossy()))
             } else {
                 PathBuf::from(format!("{}/release", data_dir.to_string_lossy()))
             };
             std::fs::create_dir_all(&formatted_data_dir)?;
 
             let formatted_logs_dir = if cfg!(dev) {
-                PathBuf::from(format!(
-                    "{}/dev/instance_{}",
-                    logs_dir.to_string_lossy(),
-                    port
-                ))
+                PathBuf::from(format!("{}/dev", logs_dir.to_string_lossy()))
             } else {
                 PathBuf::from(format!("{}/release", logs_dir.to_string_lossy()))
             };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,14 +58,12 @@ pub fn run() {
 
             setup_logging(formatted_logs_dir.clone())?;
 
+            // Open devtools on debug builds
             #[cfg(debug_assertions)]
             {
-                // Open devtools on debug builds
                 let window = app.get_webview_window("main").unwrap();
                 window.open_devtools();
                 window.close_devtools();
-                // Customize the window title based on port
-                window.set_title(&format!("White Noise (port {})", &port))?;
             }
 
             tauri::async_runtime::block_on(async move {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,6 +5,7 @@
     "identifier": "com.paper-robin.whitenoise",
     "build": {
         "beforeDevCommand": "bun run dev",
+        "devUrl": "http://localhost:1420",
         "beforeBuildCommand": "bun run build",
         "frontendDist": "../build"
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,8 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vite";
 
+// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
-const port = process.env.TAURI_DEV_PORT;
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
@@ -14,7 +14,7 @@ export default defineConfig(async () => ({
     clearScreen: false,
     // 2. tauri expects a fixed port, fail if that port is not available
     server: {
-        port: port ? Number(port) : 1420,
+        port: 1420,
         strictPort: true,
         host: host || false,
         hmr: host


### PR DESCRIPTION
This reverts commit 950336bc88d83245c387f42e7411964ede7b7d3f.

This has some problems involving `build.devUrl`, breaks frontend hot-reloading, and isn't supported by Tauri. If we ever want to add back this functionality we can resurrect it easily.