### PR TITLE
fix(long-messages): change word break style to fix long messages

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -98,3 +98,7 @@ html {
         padding-bottom: max(8px, var(--sab, 8px));
     }
 }
+
+.break-words-smart {
+    word-break: break-word;
+}

--- a/src/routes/(app)/chats/[id]/+page.svelte
+++ b/src/routes/(app)/chats/[id]/+page.svelte
@@ -346,7 +346,7 @@ onDestroy(() => {
                                 <RepliedTo messageId={message.tags.find((t) => t[0] === "q")?.[1]} />
                             {/if}
                             <div class="flex {message.content.trim().length < 50 && !isSingleEmoji(message.content) ? "flex-row gap-6" : "flex-col gap-2 justify-end w-full"} items-end {isSingleEmoji(message.content) ? 'mb-4 my-6' : ''}">
-                                <div class="break-words {isSingleEmoji(message.content) ? 'text-7xl leading-none' : ''}">
+                                <div class="break-words-smart {isSingleEmoji(message.content) ? 'text-7xl leading-none' : ''}">
                                     {#if message.content.trim().length > 0}
                                         {message.content}
                                     {:else}
@@ -437,4 +437,3 @@ onDestroy(() => {
         transition: color 0.2s ease-in-out;
     }
 </style>
-


### PR DESCRIPTION
# Context
The `break-words` tailwind style looked bad for the case of messages with really long words, like this:

<img width="1511" alt="Screenshot 2025-02-21 at 3 01 42 PM" src="https://github.com/user-attachments/assets/cab68760-1d18-4e6a-8a84-1b0983509335" />


## What has been done
A new style called break-words-smart was added to fix the problem . Now it looks like this:
<img width="1393" alt="Screenshot 2025-02-21 at 3 28 11 PM" src="https://github.com/user-attachments/assets/4166f02d-93ee-43e2-b55f-64fd504d832f" />

